### PR TITLE
compare default components and eliminate double renders

### DIFF
--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react'
 import classNames from 'classnames'
 
 import isEmpty from 'lodash/isEmpty'
+import intersection from 'lodash/intersection'
 
 import Manager from '../Manager'
 
@@ -128,7 +129,7 @@ export default class Player extends Component {
   }
 
   getDefaultChildren(originalChildren) {
-    return [
+    const defaultChildren = [
       <Video
         ref={c => {
           this.video = c
@@ -147,6 +148,18 @@ export default class Player extends Component {
       <CueBar key="cue-bar" order={6.0} />,
       <Shortcut key="shortcut" order={99.0} />,
     ]
+    const defaultChildrenKeys = defaultChildren.map(e => e.key)
+    const originalChildrenKeys = originalChildren.map(e => e.key)
+    const existingChildrenKeys = intersection(
+      originalChildrenKeys,
+      defaultChildrenKeys,
+    )
+
+    const children = defaultChildren.filter(
+      e => !existingChildrenKeys.includes(e.key),
+    )
+
+    return children
   }
 
   getChildren(props) {


### PR DESCRIPTION
When importing player components from `egghead-next`, they aren't being compared with the default stack of components that this library is importing.


This issue came up when I was importing `<CueBar />` component from `egghead-next`, resulting in double `CueBar`:
<img src="https://user-images.githubusercontent.com/25487857/121690366-0cae0a80-cac6-11eb-8ba2-ea2216f0f770.png" width="250">

This PR makes it so we compare `originalChildren[]` with `defaultChildren[]` and only return components that aren't being already declared elsewhere in player scope. Their `key` must match!

<img src="https://media.giphy.com/media/xUOwGiewfQAm3tcIA8/giphy.gif" width="120">
